### PR TITLE
Add comments for unsupported parameters

### DIFF
--- a/libs/partners/upstage/langchain_upstage/chat_models.py
+++ b/libs/partners/upstage/langchain_upstage/chat_models.py
@@ -12,10 +12,10 @@ from langchain_core.utils import (
     convert_to_secret_str,
     get_from_dict_or_env,
 )
-from langchain_openai import ChatOpenAI
+from langchain_openai.chat_models.base import BaseChatModel
 
 
-class ChatUpstage(ChatOpenAI):
+class ChatUpstage(BaseChatModel):
     """ChatUpstage chat model.
 
     To use, you should have the environment variable `UPSTAGE_API_KEY`

--- a/libs/partners/upstage/langchain_upstage/chat_models.py
+++ b/libs/partners/upstage/langchain_upstage/chat_models.py
@@ -12,10 +12,10 @@ from langchain_core.utils import (
     convert_to_secret_str,
     get_from_dict_or_env,
 )
-from langchain_openai.chat_models.base import BaseChatModel
+from langchain_openai.chat_models.base import BaseChatOpenAI
 
 
-class ChatUpstage(BaseChatModel):
+class ChatUpstage(BaseChatOpenAI):
     """ChatUpstage chat model.
 
     To use, you should have the environment variable `UPSTAGE_API_KEY`

--- a/libs/partners/upstage/langchain_upstage/chat_models.py
+++ b/libs/partners/upstage/langchain_upstage/chat_models.py
@@ -59,6 +59,16 @@ class ChatUpstage(ChatOpenAI):
     upstage_api_base: Optional[str] = Field(
         default="https://api.upstage.ai/v1/solar", alias="base_url"
     )
+    """Base URL path for API requests, leave blank if not using a proxy or service 
+    emulator."""
+    openai_api_key: Optional[SecretStr] = Field(default=None)
+    """openai api key is not supported for upstage. use `upstage_api_key` instead."""
+    openai_api_base: Optional[str] = Field(default=None)
+    """openai api base is not supported for upstage. use `upstage_api_base` instead."""
+    openai_organization: Optional[str] = Field(default=None)
+    """openai organization is not supported for upstage."""
+    tiktoken_model_name: Optional[str] = None
+    """tiktoken is not supported for upstage."""
 
     @root_validator()
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/partners/upstage/tests/integration_tests/test_embeddings.py
+++ b/libs/partners/upstage/tests/integration_tests/test_embeddings.py
@@ -1,4 +1,5 @@
 """Test Upstage embeddings."""
+
 from langchain_upstage import UpstageEmbeddings
 
 

--- a/libs/partners/upstage/tests/unit_tests/test_chat_models_standard.py
+++ b/libs/partners/upstage/tests/unit_tests/test_chat_models_standard.py
@@ -1,4 +1,5 @@
 """Standard LangChain interface tests"""
+
 from typing import Type
 
 import pytest

--- a/libs/partners/upstage/tests/unit_tests/test_embeddings.py
+++ b/libs/partners/upstage/tests/unit_tests/test_embeddings.py
@@ -1,4 +1,5 @@
 """Test embedding model integration."""
+
 import os
 
 import pytest


### PR DESCRIPTION
문서에 openai_api_key가 그대로 남아있어서 설명에 쓰이지 않는다고 추가만 했습니다.
이걸 삭제하는 방법이 있는지 모르곘네요..